### PR TITLE
Add missing GDK_KEY_VoidSymbol #define.

### DIFF
--- a/pqiv.c
+++ b/pqiv.c
@@ -74,6 +74,7 @@
 #define GDK_BUTTON_MIDDLE 2
 #define GDK_BUTTON_SECONDARY 3
 
+#define GDK_KEY_VoidSymbol 0xffffff
 #define GDK_KEY_Escape 0xff1b
 #define GDK_KEY_Return 0xff0d
 #define GDK_KEY_Left 0xff51


### PR DESCRIPTION
Else the build with fail with `pqiv.c:4446:20: error: 'GDK_KEY_VoidSymbol' undeclared (first use in this function)`