### PR TITLE
Added fflush(stdout) call after printf that prints current file name.

### DIFF
--- a/pqiv.c
+++ b/pqiv.c
@@ -2856,6 +2856,7 @@ static void status_output() {/*{{{*/
 	D_LOCK(file_tree);
 	if(file_tree_valid && current_file_node) {
 		printf("CURRENT_FILE_NAME=\"%s\"\nCURRENT_FILE_INDEX=%d\n\n", CURRENT_FILE->file_name, bostree_rank(current_file_node));
+		fflush(stdout);
 	}
 	D_UNLOCK(file_tree);
 #endif


### PR DESCRIPTION
The reason for this is some languages (e.g. C#), when you call pqiv as a subprocess, you can't get standard out live from the process unless stdout is flushed from the child process.  Otherwise, the parent process won't get any stdout until the process is closed.