### PR TITLE
fix gtk2 build

### DIFF
--- a/pqiv.c
+++ b/pqiv.c
@@ -5636,7 +5636,7 @@ int main(int argc, char *argv[]) {
 		#endif
 	#endif
 
-	#if defined(GDK_WINDOWING_X11)
+	#if defined(GDK_WINDOWING_X11) && GTK_MAJOR_VERSION >= 3
 		XInitThreads();
 	#endif
 	#if (!GLIB_CHECK_VERSION(2, 32, 0))


### PR DESCRIPTION
Call `XInitThreads()` only for gtk3. With `--gtk-version=2` for `configire`, it will cause the following error:
```
/usr/lib/libX11.so.6: error adding symbols: DSO missing from command line
```