### PR TITLE
Fixed the required libavutil version in libav backend

### DIFF
--- a/backends/libav.c
+++ b/backends/libav.c
@@ -288,7 +288,7 @@ void file_type_libav_load(file_t *file, GInputStream *data, GError **error_point
 		file->height = private->sample_aspect_ratio.den * private->pixel_height / private->sample_aspect_ratio.num;
 	}
 
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(54, 0, 0)
+#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(55, 0, 0)
 	size_t num_bytes = avpicture_get_size(PIX_FMT_RGB32, file->width, file->height);
 #else
 	size_t num_bytes = av_image_get_buffer_size(AV_PIX_FMT_RGB32, file->width, file->height, 16);
@@ -372,7 +372,7 @@ void file_type_libav_draw(file_t *file, cairo_t *cr) {/*{{{*/
 
 		// Prepare buffer for RGB32 version
 		uint8_t *buffer = private->buffer;
-#if LIBAVCODEC_VERSION_INT < AV_VERSION_INT(54, 0, 0)
+#if LIBAVUTIL_VERSION_INT < AV_VERSION_INT(55, 0, 0)
 		avpicture_fill((AVPicture *)rgb_frame, buffer, PIX_FMT_RGB32, file->width, file->height);
 #else
 		av_image_fill_arrays(rgb_frame->data, rgb_frame->linesize, buffer, AV_PIX_FMT_RGB32, file->width, file->height, 16);


### PR DESCRIPTION
av_image_get_buffer_size() and av_image_fill_arrays() is only available on libavutil major version 55 and after, and the availability of these two function depends on libavutil version, not libavcodec version.

This fixes the problem that pqiv build with libav backend fails on default Ubuntu 14.04 installation.