### PR TITLE
ACTION_ANIMATION_STEP jumps one frame too much

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -100,6 +100,7 @@ Contributors to pqiv 2.x are:
 
  * J. Paul Reed
  * Chen Jonh L
+ * Anton Älgmyr
 
 Contributors to pqiv ≤ 1.0 were:
 

--- a/pqiv.c
+++ b/pqiv.c
@@ -5956,7 +5956,9 @@ void action(pqiv_action_t action_id, pqiv_action_parameter_t parameter) {/*{{{*/
 			current_image_animation_speed_scale = 0;
 			D_LOCK(file_tree);
 			if(parameter.pint > 0 && CURRENT_FILE->file_type->animation_next_frame_fn != NULL) {
-				for(int i=0; i<parameter.pint; i++) {
+				// Skip all but one frame here, the last frame progression
+				// happens in image_animation_timeout_callback
+				for(int i = 0; i < parameter.pint - 1; i++) {
 					CURRENT_FILE->file_type->animation_next_frame_fn(CURRENT_FILE);
 				}
 			}


### PR DESCRIPTION
For all backends I tested (gdkpixbuf, libav, wand) pqiv jumps one frame too far when using ACTION_ANIMATION_STEP. Essentially for an argument `n=parameter.pint` animation_next_frame_fn is called `n` times in

```
	for(int i=0; i<parameter.pint; i++) {
		CURRENT_FILE->file_type->animation_next_frame_fn(CURRENT_FILE);
	}
```

and 1 time inside

```
	image_animation_timeout_callback(current_file_node);
```

This is easily solved by skipping `n-1` frames in the loop.