### PR TITLE
An sxiv-like marks system

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -11,7 +11,7 @@ It is optimized to be quick and responsive.
 
 It comes with support for animations, slideshows, transparency, VIM-like key
 bindings, automated loading of new images as they appear, external image
-filters, image preloading, and much more.
+filters, marks, image preloading, and much more.
 
 pqiv started as a Python rewrite of qiv avoiding imlib, but evolved into a much
 more powerful tool. Today, pqiv stands for powerful quick image viewer.
@@ -33,6 +33,7 @@ Features
  * Comes with an interactive montage mode (a.k.a. "image grid")
  * Customizable key-bindings with support for VIM-like key sequences, action
    cycling and binding multiple actions to a single key
+ * Mark/unmark images and pipe the list of marked images to an external script
 
 Installation
 ------------
@@ -103,6 +104,7 @@ Contributors to pqiv 2.x are:
  * J. Paul Reed
  * Chen Jonh L
  * Anton Älgmyr
+ * Kanon Kubose
 
 Contributors to pqiv ≤ 1.0 were:
 
@@ -177,6 +179,7 @@ Changelog
 
 pqiv 2.12 (dev)
  * Fix support for `best` interpolation quality (Fixes #139)
+ * Add an sxiv-like marks system
 
 pqiv 2.11
  * Added negate (color inversion) mode (bound to `n`, `--negate`)

--- a/pqiv.1
+++ b/pqiv.1
@@ -109,7 +109,7 @@ Bind the external \fICOMMAND\fR to key 1. You can use 2..9 to bind further
 commands. The \fBACTIONS\fR feature (see below) allows one to bind further keys to
 other commands. \fICOMMAND\fR is executed using the default shell processor.
 `$1' is substituted with the current file name. Unless \fICOMMAND\fR begins with
-`|', if `$1' is not present, the file name is appended to the command line.
+`|' or `-', if `$1' is not present, the file name is appended to the command line.
 .RS
 .PP
 If \fICOMMAND\fR begins with `>', its standard output is displayed in a popup window.
@@ -117,6 +117,9 @@ If \fICOMMAND\fR begins with `>', its standard output is displayed in a popup wi
 If \fICOMMAND\fR begins with `|', the current image is piped to its standard
 input, and its standard output is loaded as an image. This can be used to e.g.
 process images.
+.PP
+If \fICOMMAND\fR begins with `-', the currently marked images are piped to its
+standard input.
 .RE
 .\"
 .TP
@@ -395,6 +398,9 @@ Override a key binding. Remember to quote closing parenthesis inside the new
 definition by prepending a backslash. Useful in conjunction with
 \fBsend_keys(STRING)\fR to set up cyclic bindings.
 .TP
+.BR clear_marks()
+Clear all marks.
+.TP
 .BR command(STRING)
 Execute the given shell command. The syntax of the argument is the same as for
 the \fB\-\-command\-1\fR option.
@@ -613,6 +619,9 @@ window mode.
 .TP
 .BR toggle_info_box()
 Toggle the visibility of the info box.
+.TP
+.BR toggle_mark()
+Toggle the current image's mark.
 .TP
 .BR toggle_negate_mode(INT)
 Toggle negate (color inversion) mode: 0 to toggle, 1 to enable, 2 to disable.

--- a/pqiv.c
+++ b/pqiv.c
@@ -785,7 +785,9 @@ gboolean handle_input_event_timeout_callback(gpointer user_data);
 void toggle_mark(int id);
 void clear_marks();
 char *get_all_marked();
-FILE *open_memstream(char **ptr, size_t *sizeloc);  // Why not declared in .h file?
+#if defined (__GLIBC__)
+	FILE *open_memstream(char **ptr, size_t *sizeloc);
+#endif
 #endif
 #ifndef CONFIGURED_WITHOUT_MONTAGE_MODE
 gboolean montage_window_get_move_cursor_target(int, int, int, int*, int*, int*, BOSNode **);

--- a/pqiv.c
+++ b/pqiv.c
@@ -705,7 +705,7 @@ const struct pqiv_action_descriptor {
 	{ "move_window", PARAMETER_2SHORT },
 	{ "toggle_background_pattern", PARAMETER_INT },
 	{ "toggle_negate_mode", PARAMETER_INT },
-	{ "toggle_mark", PARAMETER_INT },
+	{ "toggle_mark", PARAMETER_NONE },
 	{ "clear_marks", PARAMETER_NONE },
 	{ NULL, 0 }
 };
@@ -782,12 +782,9 @@ void draw_current_image_to_context(cairo_t *cr);
 gboolean window_auto_hide_cursor_callback(gpointer user_data);
 #ifndef CONFIGURED_WITHOUT_ACTIONS
 gboolean handle_input_event_timeout_callback(gpointer user_data);
-void toggle_mark(int id);
+void toggle_mark();
 void clear_marks();
-char *get_all_marked();
-#if defined (__GLIBC__)
-	FILE *open_memstream(char **ptr, size_t *sizeloc);
-#endif
+GString *get_all_marked();
 #endif
 #ifndef CONFIGURED_WITHOUT_MONTAGE_MODE
 gboolean montage_window_get_move_cursor_target(int, int, int, int*, int*, int*, BOSNode **);
@@ -1529,7 +1526,6 @@ void load_images_handle_parameter(char *param, load_images_state_t state, gint d
 	// Check for memory image
 	if(state == PARAMETER && g_strcmp0(param, "-") == 0) {
 		file = g_slice_new0(file_t);
-		file->marked = -1;
 		file->file_flags = FILE_FLAGS_MEMORY_IMAGE;
 		file->display_name = g_strdup("-");
 		if(option_sort) {
@@ -1729,7 +1725,6 @@ void load_images_handle_parameter(char *param, load_images_state_t state, gint d
 		file = g_slice_new0(file_t);
 		file->file_name = g_strdup(param);
 		file->display_name = g_filename_display_name(param);
-		file->marked = -1;
 		g_mutex_init(&file->lock);
 		if(option_sort) {
 			if(option_sort_key == MTIME) {
@@ -3540,22 +3535,49 @@ void apply_external_image_filter(gchar *external_filter) {/*{{{*/
 		// Reminder: Do not free the others, they are string constants
 		g_free(argv[2]);
 	}
-	else if(external_filter[0] == '<') {
-		char *marklist = get_all_marked();
-		// argv[2] = apply_external_image_filter_prepare_command(external_filter + 1);
-		// printf("%s\n", argv[2]);
-		// This does it a different way, so rest of argv not used.
-		// if(g_spawn_async(NULL, argv, NULL, 0, NULL, NULL, NULL, &error_pointer) == FALSE) {  // For diff between this and popen, see: https://stackoverflow.com/questions/219138/get-command-output-in-pipe-c-for-linux
-		FILE *fp = popen(external_filter + 1, "w");
-		if(!fp) {
+	else if(external_filter[0] == '-') {
+		GString *marklist = get_all_marked();
+		argv[2] = external_filter + 1;
+		GPid child_pid;
+		gint child_stdin;
+		if(!g_spawn_async_with_pipes(NULL, argv, NULL,
+			// In win32, the G_SPAWN_DO_NOT_REAP_CHILD is required to get the process handle
+			#ifdef _WIN32
+				G_SPAWN_DO_NOT_REAP_CHILD,
+			#else
+				0,
+			#endif
+			NULL, NULL, &child_pid, &child_stdin, NULL, NULL, &error_pointer)
+		) {
 			g_printerr("Failed execute external command `%s': %s\n", argv[2], error_pointer->message);
 			g_clear_error(&error_pointer);
-		} else {
-			fprintf(fp, "%s", marklist);
-			pclose(fp);
 		}
-		// g_free(argv[2]);
-		free(marklist);
+		else {
+			if(write(child_stdin, marklist->str, marklist->len) == -1) {
+				g_printerr("Failed writing to stdin of %s\n", argv[2]);
+			}
+			close(child_stdin);
+			gint status = 0;  // When left uninitialized, external command reports exiting due to signal 95 (exit statuses have been 233, 201, 217). Why?
+			#ifdef _WIN32
+				WaitForSingleObject(child_pid, INFINITE);
+				DWORD exit_code = 0;
+				GetExitCodeProcess(child_pid, &exit_code);
+				status = (gint)exit_code;
+			#else
+				waitpid(child_pid, &status, 0);
+			#endif
+			g_spawn_close_pid(child_pid);
+
+			if (!WIFEXITED(status)) {
+				if (WIFSIGNALED(status)) {
+					g_printerr("External command exited due to signal %d (exit status: %d)\n", WTERMSIG(status), WEXITSTATUS(status));
+				}
+				else {
+					g_printerr("External command failed with exit status %d\n", WEXITSTATUS(status));
+				}
+			}
+		}
+		g_string_free(marklist, TRUE);
 	}
 	else if(external_filter[0] == '|') {
 		// Pipe image into program, read image from its stdout
@@ -4795,8 +4817,7 @@ gboolean window_draw_thumbnail_montage(cairo_t *cr_arg) {/*{{{*/
 			}
 
 			// Marks
-			if(thumb_file->marked == 1) {
-				// printf("%s is marked\n", thumb_file->display_name);
+			if(thumb_file->marked) {
 				int markx = cairo_image_surface_get_width(thumb_file->thumbnail);
 				int marky = cairo_image_surface_get_height(thumb_file->thumbnail);
 				cairo_rectangle(cr_arg, markx - 5, marky - 5, markx + 1, marky + 1);
@@ -6591,7 +6612,7 @@ void action(pqiv_action_t action_id, pqiv_action_parameter_t parameter) {/*{{{*/
 			break;
 #endif // without montage
 		case ACTION_TOGGLE_MARK:
-			toggle_mark(parameter.pint);
+			toggle_mark();
 			break;
 
 		case ACTION_CLEAR_MARKS:
@@ -8039,6 +8060,40 @@ gboolean inner_main(void *user_data) {/*{{{*/
 
 	return FALSE;
 }/*}}}*/
+
+/* Marks system functions {{{ */
+void clear_marks() {/*{{{*/
+	D_LOCK(file_tree);
+	for(BOSNode *iter = bostree_select(file_tree, 0); iter; iter = bostree_next_node(iter)) {
+		FILE(iter)->marked = FALSE;
+	}
+	D_UNLOCK(file_tree);
+}/*}}}*/
+void toggle_mark() {/*{{{*/
+	if(application_mode == DEFAULT) {
+		FILE(current_file_node)->marked = !FILE(current_file_node)->marked;
+	}
+	#ifndef CONFIGURED_WITHOUT_MONTAGE_MODE
+	else if(application_mode == MONTAGE) {
+		FILE(montage_window_control.selected_node)->marked = !FILE(montage_window_control.selected_node)->marked;
+	}
+	#endif
+}/*}}}*/
+GString *get_all_marked() {/*{{{*/
+	GString *result = g_string_new(NULL);
+
+	D_LOCK(file_tree);
+	for(BOSNode *iter = bostree_select(file_tree, 0); iter; iter = bostree_next_node(iter)) {
+		file_t *file = FILE(iter);
+		if(file->marked) {
+			g_string_append_printf(result, "%s\n", file->file_name);
+		}
+	}
+	D_UNLOCK(file_tree);
+	return result;
+}/*}}}*/
+// }}}
+
 int main(int argc, char *argv[]) {
 	#ifdef DEBUG
 		#ifndef _WIN32
@@ -8145,53 +8200,5 @@ int main(int argc, char *argv[]) {
 	D_UNLOCK(file_tree);
 
 	return 0;
-}
-
-void clear_marks() {
-	D_LOCK(file_tree);
-	printf("Clearing marks\n");
-	for(BOSNode *iter = bostree_select(file_tree, 0); iter; iter = bostree_next_node(iter)) {
-		FILE(iter)->marked = -1;
-	}
-	D_UNLOCK(file_tree);
-}
-
-void toggle_mark(int id) {
-	// Not using id for now. Just mark current.
-
-	if(application_mode == DEFAULT) {
-		if(FILE(current_file_node)->marked == 1) {
-			FILE(current_file_node)->marked = -1;
-		} else {
-			FILE(current_file_node)->marked = 1;
-		}
-	}
-	#ifndef CONFIGURED_WITHOUT_MONTAGE_MODE
-	else if(application_mode == MONTAGE) {
-		if(FILE(montage_window_control.selected_node)->marked == 1) {
-			FILE(montage_window_control.selected_node)->marked = -1;
-		} else {
-			FILE(montage_window_control.selected_node)->marked = 1;
-		}
-	}
-	#endif
-}
-
-char *get_all_marked() {
-	char* result = NULL;
-	size_t resultSize = 0;
-	FILE* stream = open_memstream(&result, &resultSize);
-
-	printf("Getting all marks\n");
-	D_LOCK(file_tree);
-	for(BOSNode *iter = bostree_select(file_tree, 0); iter; iter = bostree_next_node(iter)) {
-		file_t *file = FILE(iter);
-		if(file->marked == 1) {
-			fprintf(stream, "%s\n", file->file_name);
-		}
-	}
-	D_UNLOCK(file_tree);
-	fclose(stream);
-	return result;
 }
 // vim:noet ts=4 sw=4 tw=0 fdm=marker

--- a/pqiv.c
+++ b/pqiv.c
@@ -1521,6 +1521,7 @@ void load_images_handle_parameter(char *param, load_images_state_t state, gint d
 	// Check for memory image
 	if(state == PARAMETER && g_strcmp0(param, "-") == 0) {
 		file = g_slice_new0(file_t);
+		file->marked = -1;
 		file->file_flags = FILE_FLAGS_MEMORY_IMAGE;
 		file->display_name = g_strdup("-");
 		if(option_sort) {
@@ -1720,6 +1721,11 @@ void load_images_handle_parameter(char *param, load_images_state_t state, gint d
 		file = g_slice_new0(file_t);
 		file->file_name = g_strdup(param);
 		file->display_name = g_filename_display_name(param);
+		printf("%s -> %s\n", file->file_name, file->display_name);
+		if(strcmp(file->file_name, "/home/kanon/Downloads/bDA2AnF.gif") == 0) {
+			file->marked = 1;
+		} else
+			file->marked = -1;
 		g_mutex_init(&file->lock);
 		if(option_sort) {
 			if(option_sort_key == MTIME) {
@@ -4695,6 +4701,8 @@ void window_draw_thumbnail_montage_show_binding_overlays_looper(gpointer key, gp
 }/*}}}*/
 #endif
 gboolean window_draw_thumbnail_montage(cairo_t *cr_arg) {/*{{{*/
+	int markx, marky;
+
 	D_LOCK(file_tree);
 
 	// Draw black background
@@ -4765,6 +4773,19 @@ gboolean window_draw_thumbnail_montage(cairo_t *cr_arg) {/*{{{*/
 				cairo_set_source_rgb(cr_arg, option_box_colors.bg_red, option_box_colors.bg_green, option_box_colors.bg_blue);
 				cairo_set_line_width(cr_arg, 8.);
 				cairo_stroke(cr_arg);
+			}
+
+			// Marks
+			if(thumb_file->marked == 1) {
+				// printf("%s is marked\n", thumb_file->display_name);
+				markx = cairo_image_surface_get_width(thumb_file->thumbnail);
+				marky = cairo_image_surface_get_height(thumb_file->thumbnail);
+				cairo_rectangle(cr_arg, markx - 5, marky - 5, markx + 1, marky + 1);
+				cairo_set_source_rgb(cr_arg, 0, 0, 0);
+				cairo_set_line_width(cr_arg, 1);
+				cairo_stroke_preserve(cr_arg);
+				cairo_set_source_rgb(cr_arg, 1, 1, 1);
+				cairo_fill(cr_arg);
 			}
 
 			cairo_restore(cr_arg);

--- a/pqiv.c
+++ b/pqiv.c
@@ -8116,4 +8116,12 @@ int main(int argc, char *argv[]) {
 	return 0;
 }
 
+void clear_marks() {
+	D_LOCK(file_tree);
+	for(BOSNode *iter = bostree_select(file_tree, 0); iter; iter = bostree_next_node(iter)) {
+		iter->marked = -1;
+	}
+	D_UNLOCK(file_tree);
+}
+
 // vim:noet ts=4 sw=4 tw=0 fdm=marker

--- a/pqiv.h
+++ b/pqiv.h
@@ -288,12 +288,8 @@ typedef enum {
 	ACTION_MOVE_WINDOW,
 	ACTION_TOGGLE_BACKGROUND_PATTERN,
 	ACTION_TOGGLE_NEGATE_MODE,
-<<<<<<< HEAD
-=======
-	ACTION_TOGGLE_BACKGROUND_GRADIENT,
 	ACTION_TOGGLE_MARK,
 	ACTION_CLEAR_MARKS,
->>>>>>> bdf7686... Initial marks code working
 } pqiv_action_t;
 
 typedef union {

--- a/pqiv.h
+++ b/pqiv.h
@@ -106,6 +106,9 @@ struct _file {
 
 	// File-type specific data, allocated and freed by the file type handlers
 	void *private;
+
+	// 1 = marked, -1 = unmarked
+	int marked;
 };
 // }}}
 // Definition of the built-in file types {{{

--- a/pqiv.h
+++ b/pqiv.h
@@ -107,8 +107,8 @@ struct _file {
 	// File-type specific data, allocated and freed by the file type handlers
 	void *private;
 
-	// 1 = marked, -1 = unmarked
-	int marked;
+	// TRUE if file is marked
+	gboolean marked;
 };
 // }}}
 // Definition of the built-in file types {{{

--- a/pqiv.h
+++ b/pqiv.h
@@ -288,6 +288,12 @@ typedef enum {
 	ACTION_MOVE_WINDOW,
 	ACTION_TOGGLE_BACKGROUND_PATTERN,
 	ACTION_TOGGLE_NEGATE_MODE,
+<<<<<<< HEAD
+=======
+	ACTION_TOGGLE_BACKGROUND_GRADIENT,
+	ACTION_TOGGLE_MARK,
+	ACTION_CLEAR_MARKS,
+>>>>>>> bdf7686... Initial marks code working
 } pqiv_action_t;
 
 typedef union {


### PR DESCRIPTION
I missed how sxiv has a marks system, so I put together one for pqiv. Currently, you can toggle marks (see them in montage mode), clear all marks, and pipe all marked files to an external `command()` by prefacing with `-` (e.g. in pqivrc, put a keybinding to `command(-cat)` (or other external command besides `cat`)).

Example keybinds to actually use it (add to pqivrc in both regular and montage mode sections):
```
m { toggle_mark() }
<Control>m { clear_marks() }
<Control>i { command(-cat) }
```