### PR TITLE
Bring window to foreground at start up on macos

### DIFF
--- a/configure
+++ b/configure
@@ -230,6 +230,8 @@ if [ -n "$CROSS" -a -z "$CC" ]; then
 	else
 		echo "ok"
 	fi
+elif [ "$(uname -s)" = "Darwin" ]; then
+	LDFLAGS="$LDFLAGS -framework Cocoa"
 fi
 
 # Determine binary extension (for Windows)

--- a/pqiv.c
+++ b/pqiv.c
@@ -62,6 +62,10 @@
 	#if GTK_MAJOR_VERSION < 3
 		#include <X11/Xatom.h>
 	#endif
+#elif defined(__APPLE__)
+#include <objc/objc.h>
+#include <objc/message.h>
+extern id NSApp;
 #endif
 
 #ifdef DEBUG
@@ -8062,6 +8066,11 @@ int main(int argc, char *argv[]) {
 			option_lazy_load = TRUE;
 		}
 	}
+
+#ifdef __APPLE__
+	SEL activateIgnoringOtherAppsSel = sel_registerName("activateIgnoringOtherApps:");
+	((void (*)(id, SEL, BOOL))objc_msgSend)(NSApp, activateIgnoringOtherAppsSel, YES);
+#endif
 
 	// Start image loader & show window inside main loop, in order to have
 	// gtk_main_quit() available.


### PR DESCRIPTION
Should fix issue #140. The idea came from my recent visit to [this project](https://github.com/jimon/osx_app_in_plain_c). It works on my Mac running OS X El Capitan.