### PR TITLE
config: mark nolocale argument const

### DIFF
--- a/pqiv.c
+++ b/pqiv.c
@@ -1229,7 +1229,7 @@ void parse_configuration_file_callback(char *section, char *key, config_parser_v
 #endif
 }
 
-static void parse_configuration_file_nolocale(gchar *config_file) {
+static void parse_configuration_file_nolocale(const gchar *config_file) {
 	gchar *old_locale = g_strdup(setlocale(LC_NUMERIC, NULL));
 	setlocale(LC_NUMERIC, "C");
 


### PR DESCRIPTION
Otherwise GCC complains about discarding const qualifier. This fixes
a99ca671312abdbfd4341557857977064d645b1f.

Signed-off-by: Oleksandr Natalenko <oleksandr@natalenko.name>