### PR TITLE
remove extraneous "-" from ---box-colors

### DIFF
--- a/pqiv.1
+++ b/pqiv.1
@@ -180,7 +180,7 @@ and insert the special key bindings within the curly braces.
 .RE
 .\"
 .TP
-.BR \-\--box\-colors=\fIFOREGROUND\ COLOR:BACKGROUND\ COLOR\fR
+.BR \-\-box\-colors=\fIFOREGROUND\ COLOR:BACKGROUND\ COLOR\fR
 Customize the colors used to draw the info box and montage mode borders. Colors
 can be specified either as a comma separated list of RBG-values in the range
 from 0 to 255 or as a hexvalue, e.g., #aabbcc. The default value is


### PR DESCRIPTION
Noticed this when working on another change. `man pqiv` documents ---box-colors due to extra "-"