### PR TITLE
config: keep shift modifier for keys that can't be uppercased

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -103,6 +103,7 @@ Contributors to pqiv 2.x are:
  * J. Paul Reed
  * Chen Jonh L
  * Anton Älgmyr
+ * Christian Garbs
 
 Contributors to pqiv ≤ 1.0 were:
 
@@ -179,6 +180,7 @@ pqiv 2.12 (dev)
  * Fix support for `best` interpolation quality (Fixes #139)
  * Fix wrap-around in shuffled image view (Fixes #176)
  * Fix max-depth behavior if the argument is a file (Fixes #170)
+ * Allow keybinding of special keys with shift modifier
 
 pqiv 2.11
  * Added negate (color inversion) mode (bound to `n`, `--negate`)


### PR DESCRIPTION
I wanted to bind a file deletion command to shift-delete, but found out it was bound to plain delete instead.

Example:

```
$ ./pqiv --bind-key '<Shift>a        { command( echo Shift a ); }' \
         --bind-key '<Shift><Delete> { command( echo Shift Delete ); }' \
         --show-bindings | grep echo
```
prints
```
                     <Delete>  { command(echo Shift Delete ) } 
                            A  { command(echo Shift a ) } 
```

The problem was that the `<Delete>` key can't be uppercased by `gdk_keyval_to_upper()`. So I've added a check to see if the uppercase keyval is different from before and only then the shift modifier is removed.

The example from above now prints the expected
```
                            A  { command(echo Shift a ) } 
              <Shift><Delete>  { command(echo Shift Delete ) } 
```