### PR TITLE
Fix fullscreen toggle bug

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -180,8 +180,8 @@ For some advanced uses of pqiv, take a look at these resouces:
 Changelog
 ---------
 
-pqiv 2.13
- * Fix toggle_fullscreen(1/2) behavior when already fullscreen
+pqiv 2.13 (dev)
+ * Fix `toggle_fullscreen(1/2)` behavior when already fullscreen
 
 pqiv 2.12
  * Fix external image filters (Fixes #182)

--- a/README.markdown
+++ b/README.markdown
@@ -107,6 +107,7 @@ Contributors to pqiv 2.x are:
  * Anton Älgmyr
  * Christian Garbs
  * Kanon Kubose
+ * Wessel Dankers
 
 Contributors to pqiv ≤ 1.0 were:
 
@@ -178,6 +179,9 @@ For some advanced uses of pqiv, take a look at these resouces:
 
 Changelog
 ---------
+
+pqiv 2.13
+ * Fix toggle_fullscreen(1/2) behavior when already fullscreen
 
 pqiv 2.12
  * Fix external image filters (Fixes #182)

--- a/pqiv.c
+++ b/pqiv.c
@@ -4146,6 +4146,8 @@ gboolean window_fullscreen_helper_reset_transition_id() {/*{{{*/
 	return FALSE;
 }/*}}}*/
 void window_fullscreen() {/*{{{*/
+	if(main_window_in_fullscreen) return;
+
 	if(is_current_file_loaded()) {
 		main_window_in_fullscreen = TRUE;
 		image_generate_prerendered_view(CURRENT_FILE, FALSE, -1);
@@ -4185,6 +4187,8 @@ void window_fullscreen() {/*{{{*/
 	gtk_window_fullscreen(main_window);
 }/*}}}*/
 void window_unfullscreen() {/*{{{*/
+	if(!main_window_in_fullscreen) return;
+
 	if(is_current_file_loaded()) {
 		main_window_in_fullscreen = FALSE;
 		image_generate_prerendered_view(CURRENT_FILE, FALSE, -1);


### PR DESCRIPTION
To reproduce:

1) Bind a key to toggle_fullscreen(2):
```
[keybindings]
<Escape> { toggle_fullscreen(2); }
```
2) Start pqiv with otherwise default options and keybindings, with a filename as argument

3) Press `Escape`

4) Press `f` (as often as you like)

Expected behavior: `f` in step 4 toggles fullscreen mode

Observed behavior: nothing happens.

Root cause:

a) The `Escape` in step 3 tries to leave fullscreen even when fullscreen is not active.

b) window_unfullscreen() then tries to set main_window_in_fullscreen to `FALSE` temporarily (even though it already was `FALSE`) then "restore" it incorrectly by setting it to `TRUE`.

c) This means main_window_in_fullscreen is now out of sync with reality.

d) From this point on, any attempt to toggle it will try to toggle it in the wrong direction.

Debug trace (pressed `Escape` once, then `f` twice):
```
pqiv.c:5748: action(): main_window_in_fullscreen=0 parameter.pint=2
pqiv.c:4191: window_unfullscreen(): main_window_in_fullscreen=0
pqiv.c:4230: window_unfullscreen(): main_window_in_fullscreen=1
pqiv.c:5748: action(): main_window_in_fullscreen=1 parameter.pint=0
pqiv.c:4191: window_unfullscreen(): main_window_in_fullscreen=1
pqiv.c:4230: window_unfullscreen(): main_window_in_fullscreen=1
pqiv.c:5748: action(): main_window_in_fullscreen=1 parameter.pint=0
pqiv.c:4191: window_unfullscreen(): main_window_in_fullscreen=1
pqiv.c:4230: window_unfullscreen(): main_window_in_fullscreen=1
```