### PR TITLE
Use larger thumbnails from newer spec

### DIFF
--- a/pqiv.1
+++ b/pqiv.1
@@ -622,8 +622,7 @@ the feature.
 .BR set_thumbnail_size(INT, INT)
 Change the size of thumbnails. The order of the arguments is width, then
 height. Thumbnails are always scaled such that no side is larger than this
-limit. Note that the persistent thumbnail cache only supports 128x128 and
-256x256 thumbnails.
+limit.
 .TP
 .BR shift_x(INT)
 Shift the current image in x direction.

--- a/pqiv.1
+++ b/pqiv.1
@@ -324,7 +324,7 @@ montage mode, but will lead to high CPU loads.
 Persist thumbnails to disk. The simplest way to use this option is to supply
 a value of \fIyes\fR. Thumbnails are then stored according to the Thumbnail
 Managing Standard, in \fI$XDG_CACHE_HOME/thumbnails/*\fR. The standard allows
-storage of thumbnails in sizes 128x128 and 256x256 exclusively, and does not
+storage of thumbnails in sizes 128x128, 256x256, 512x512 and 1024x1024 exclusively, and does not
 specify how to store thumbnails for files in archives or multi-page documents.
 Thumbnails violating those constraints will be stored in a special \fIx-pqiv\fR
 subfolder. Supply \fIstandard\fR to store standard compliant thumbnails only.


### PR DESCRIPTION
Closes https://github.com/phillipberndt/pqiv/issues/198 after small refactoring.

No attempt is made to move around existing large thumbnails from x-pqiv/512 and x-pqiv/1024 to the new locations; that seems extraneous.

Tests performed with the new x-large size:
* Loading of thumbnails generated in sh_thumbs for the large sizes by [an external tool](https://github.com/jesjimher/genthumbs/)
* Generating thumbnails both with --thumbnail-persistence=local and with =shared
* Loading own generated thumbnails from either location