### PR TITLE
.desktop file: Run pqiv --browse

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -211,7 +211,7 @@ pqiv.desktop: $(HEADERS)
 		echo "NoDisplay=true"; \
 		echo "Icon=emblem-photos"; \
 		echo "TryExec=$(PREFIX)/bin/pqiv"; \
-		echo "Exec=$(PREFIX)/bin/pqiv %F"; \
+		echo "Exec=$(PREFIX)/bin/pqiv --browse %F"; \
 		echo "MimeType=$(shell cat $(foreach BACKEND, $(sort $(BACKENDS)), $(SOURCEDIR)backends/$(BACKEND).mime) /dev/null | sort | uniq | awk 'ORS=";"')"; \
 		echo "Categories=Graphics;"; \
 		echo "Keywords=Viewer;" \


### PR DESCRIPTION
This ensures that people opening pqiv from the file manager can still
access the rest of the files in the directory, as is common with image
viewers.

Contributes-To: https://github.com/phillipberndt/pqiv/issues/201