### PR TITLE
Use Pango to render infobox text.

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -46,7 +46,7 @@ $(error Building pqiv without any backends is unsupported.)
 endif
 
 # pkg-config lines for the main program
-LIBS_GENERAL=glib-2.0 >= 2.8 cairo >= 1.6 gio-2.0
+LIBS_GENERAL=glib-2.0 >= 2.8 cairo >= 1.6 pango >= 1.10 gio-2.0
 LIBS_GTK3=gtk+-3.0 gdk-3.0
 LIBS_GTK2=gtk+-2.0 >= 2.6 gdk-2.0 >= 2.8
 

--- a/README.markdown
+++ b/README.markdown
@@ -64,6 +64,7 @@ If you'd like to compile pqiv manually, you'll need
  * gdk-pixbuf 2.2 (included in gtk+)
  * glib 2.32 (with gvfs for opening URLs)
  * cairo 1.6
+ * Pango 1.10
  * gio 2.0
  * gdk 2.8
 

--- a/pqiv.1
+++ b/pqiv.1
@@ -38,6 +38,11 @@ Initially hide the info box. Whether the box is visible can be toggled by
 pressing \fBi\fR at runtime by default.
 .\"
 .TP
+.BR \-\-font=\fIFONT\fR
+Specify the Pango font string for the info box. Note that the font size
+will be scaled to the window.
+.\"
+.TP
 .BR \-l ", " \-\-lazy\-load
 \fBpqiv\fR normally processes all command line arguments before displaying its
 main window. With this option, the window is shown as soon as the first image


### PR DESCRIPTION
Cairo's built-in Unicode handling is limited and does not properly render certain scripts. Pango has close integration with Cairo and provides complete Unicode character rendering.

The `--font` argument is also added to allow the desired font to be passed to Pango from the command line or configuration. 'Sans-Serif' is used by default with the preexisting size of 12. In the case that the desired size is too large, it will be scaled down as before.