### PR TITLE
manpage: Fix options for --sort-key

### DIFF
--- a/pqiv.1
+++ b/pqiv.1
@@ -307,10 +307,10 @@ bindings in the format accepted by \fB\-\-bind\-key\fR. See there, and the
 .BR \-\-sort\-key=\fIPROPERTY\fR
 Key to use for sorting. Supported values for \fIPROPERTY\fR are:
 .RS
-.IP NAME 8
+.IP name 8
 To sort by filename in natural order, e.g. \fIabc32d\fR before \fIabc112d\fR,
 but \fIb1\fR after both,
-.IP MTIME
+.IP mtime
 To sort by file modification date.
 .RE
 .\"


### PR DESCRIPTION
The options are listed in uppercase, even though pqiv accepts them as lowercase