### PR TITLE
Fix for only build error with C23

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -167,7 +167,7 @@ ifndef VERBOSE
 endif
 
 # Assemble final compiler flags
-CFLAGS_REAL=-std=gnu99 $(PQIV_WARNING_FLAGS) $(PQIV_VERSION_FLAG) $(CFLAGS) $(DEBUG_CFLAGS) $(EXTRA_DEFS) $(shell $(PKG_CONFIG) --cflags "$(LIBS)")
+CFLAGS_REAL=$(PQIV_WARNING_FLAGS) $(PQIV_VERSION_FLAG) $(CFLAGS) $(DEBUG_CFLAGS) $(EXTRA_DEFS) $(shell $(PKG_CONFIG) --cflags "$(LIBS)")
 LDLIBS_REAL=$(shell $(PKG_CONFIG) --libs "$(LIBS)") $(LDLIBS)
 LDFLAGS_REAL=$(LDFLAGS)
 

--- a/pqiv.c
+++ b/pqiv.c
@@ -4159,7 +4159,7 @@ void do_jump_dialog() { /* {{{ */
 #endif
 // }}}
 /* Main window functions {{{ */
-gboolean window_fullscreen_helper_reset_transition_id() {/*{{{*/
+gboolean window_fullscreen_helper_reset_transition_id(void *) {/*{{{*/
 	action_done();
 	fullscreen_transition_source_id = -1;
 	return FALSE;


### PR DESCRIPTION
Also removes hardcoded std=gnu99, allowing modern compilers to use all features.
Closes #251