### PR TITLE
add gcc's -fanalyzer, fix found NULL derefs

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,7 +6,7 @@ CFLAGS?=-O2 -g
 CROSS=
 DESTDIR=
 GTK_VERSION=0
-PQIV_WARNING_FLAGS=-Wall -Wextra -Wfloat-equal -Wpointer-arith -Wcast-align -Wstrict-overflow=1 -Wwrite-strings -Waggregate-return -Wunreachable-code -Wno-unused-parameter
+PQIV_WARNING_FLAGS=-Wall -Wextra -Wfloat-equal -Wpointer-arith -Wcast-align -Wstrict-overflow=1 -Wwrite-strings -Waggregate-return -Wunreachable-code -Wno-unused-parameter -fanalyzer
 LDLIBS=-lm
 PREFIX=/usr
 EPREFIX=$(PREFIX)

--- a/GNUmakefile
+++ b/GNUmakefile
@@ -6,7 +6,7 @@ CFLAGS?=-O2 -g
 CROSS=
 DESTDIR=
 GTK_VERSION=0
-PQIV_WARNING_FLAGS=-Wall -Wextra -Wfloat-equal -Wpointer-arith -Wcast-align -Wstrict-overflow=1 -Wwrite-strings -Waggregate-return -Wunreachable-code -Wno-unused-parameter -fanalyzer
+PQIV_WARNING_FLAGS=-Wall -Wextra -Wfloat-equal -Wpointer-arith -Wcast-align -Wstrict-overflow=1 -Wwrite-strings -Waggregate-return -Wunreachable-code -Wno-unused-parameter
 LDLIBS=-lm
 PREFIX=/usr
 EPREFIX=$(PREFIX)
@@ -24,6 +24,11 @@ EXTRA_CFLAGS_SHARED_OBJECTS=-fPIC
 EXTRA_CFLAGS_BINARY=
 EXTRA_LDFLAGS_SHARED_OBJECTS=
 EXTRA_LDFLAGS_BINARY=
+
+# If compiler is gcc, enable static analyzer
+ifneq ($(findstring gcc, $(CC)),)
+	PQIV_WARNING_FLAGS+=-fanalyzer
+endif
 
 # Always look for source code relative to the directory of this makefile
 SOURCEDIR:=$(dir $(abspath $(lastword $(MAKEFILE_LIST))))

--- a/lib/bostree.c
+++ b/lib/bostree.c
@@ -132,6 +132,10 @@ static BOSNode *_bostree_rotate_left(BOSTree *tree, BOSNode *P) {
 /* API implementation */
 BOSTree *bostree_new(BOSTree_cmp_function cmp_function, BOSTree_free_function free_function) {
 	BOSTree *new_tree = malloc(sizeof(BOSTree));
+	// If no memory, die.
+	if(NULL == new_tree) {
+		abort();
+	}
 	new_tree->root_node = NULL;
 	new_tree->cmp_function = cmp_function;
 	new_tree->free_function = free_function;
@@ -195,6 +199,14 @@ BOSNode *bostree_insert(BOSTree *tree, void *key, void *data) {
 	// Create new node
 	BOSNode *new_node = malloc(sizeof(BOSNode));
 	memset(new_node, 0, sizeof(BOSNode));
+	// Memset can return NULL if there's not enough free memory.
+	// We can return null and pretend everything is ok.
+	// Or we can abort because something is significantly wrong
+	// with system, and lettign it have some memory is more
+	// important than looking at pictures. Sorry.
+	if(NULL == new_node) {
+		abort();
+	}
 	new_node->key = key;
 	new_node->data = data;
 	new_node->weak_ref_count = 1;
@@ -564,6 +576,9 @@ BOSNode *bostree_previous_node(BOSNode *node) {
 }
 
 unsigned int bostree_rank(BOSNode *node) {
+	if(NULL==node){
+		return 0;
+	}
 	unsigned int counter = node->left_child_count;
 	while(node) {
 		if(node->parent_node && node->parent_node->right_child_node == node) counter += 1 + node->parent_node->left_child_count;

--- a/lib/config_parser.c
+++ b/lib/config_parser.c
@@ -126,6 +126,10 @@ static void _config_parser_parse_data_invoke_callback(config_parser_callback_t c
 }
 
 void config_parser_parse_data(char *file_data, size_t file_length, config_parser_callback_t callback) {
+	//In some unlikely, but possible code paths file_data could be NULL; guard agains that
+	if(NULL==file_data) {
+		abort();
+	}
 	enum { DEFAULT, SECTION_IDENTIFIER, COMMENT, VALUE } state = DEFAULT;
 	int section_had_keys = 0;
 	char *section_start = NULL, *section_end = NULL, *key_start = NULL, *key_end = NULL, *data_start = NULL, *value_start = NULL;


### PR DESCRIPTION
GCC has build-in static analyzer, enabled by `-fanalyzer` that helps to find tricky control flow problems. In this case, it found three possible null dereferences.

I was not confident in how to best deal with them, so `abort()` was my go-to solution.
In two places it's due to no memory for nodes left. I am mostly sure about this.
In one place it was for failure to read a config file, I am not sure about this, hence commit with full analyzer output.